### PR TITLE
Temporary quick fix to UserCard refresh problem

### DIFF
--- a/components/user-card.jsx
+++ b/components/user-card.jsx
@@ -57,9 +57,9 @@ export default function UserCard(props) {
   const classes = useStyles();
 
   // User info setup
-  const split = splitName(props.person.person.displayName)
+  let split = splitName(props.person.person.displayName)
   const [user, modifyUser] = React.useState({...props.person.person, firstName: split.firstName, lastName: split.lastName})
-  const {displayName, email, phone, firstName, lastName} = user;
+  let {displayName, email, phone, firstName, lastName} = user;
 
   // Firebase setup
   const [fbUser, setFbUser] = React.useState(null)
@@ -67,6 +67,11 @@ export default function UserCard(props) {
     firebase.auth().onAuthStateChanged(function(user) {
       if (user) {
         setFbUser(user)
+        displayName = user.displayName
+        split = splitName(displayName)
+        firstName = split.firstName
+        lastName = split.lastName
+        modifyUser({...props.person.person, firstName: split.firstName, lastName: split.lastName})
       }
     });
   }, [])


### PR DESCRIPTION
Refreshing after a UserCard update returns the card to its former state
because the card takes its information from the props, which itself is
simply the passing around of the original user object. As a quick hack,
we reconstruct the user attributes on mount when the auth state has
changed, and thus we have the new state, even if there is a noticeable lag